### PR TITLE
Fix collection 2.3 download

### DIFF
--- a/app/views/pages/database/mapbiomas_collection.en.html.erb
+++ b/app/views/pages/database/mapbiomas_collection.en.html.erb
@@ -22,26 +22,31 @@
     });
   }
 
-  $(document).on('change', '#collection', function() {
-    if($(this).val() == '1') {
+  function setupOptions() {
+    var value = $('#collection').val();
+
+    if(value == '1') {
       $('#year').find('option').prop('disabled', false);
       $('#year').find('option[value="2016"]', 'option').prop('disabled', true);
       $('#year').find('option[value="all_years"]', 'option').prop('disabled', true);
       $('#year').find('option:first-child').prop('selected', true)
-    } else if($(this).val() == '2') {
+    } else if(value == '2') {
       $('#year').find('option').prop('disabled', false);
       $('#year').find('option[value="2016"]').prop('disabled', false);
       $('#year').find('option[value="all_years"]', 'option').prop('disabled', true);
       $('#year').find('option:first-child').prop('selected', true)
     } else {
-      $('#year').find('option').prop('disabled', true);
-      $('#year').find('option[value="all_years"]').prop('disabled', false);
+      $('#year').find('option[value!="all_years"]').prop('disabled', true);
       $('#year').find('option[value="all_years"]').prop('selected', true);
     }
 
     $('#year').trigger('change');
     
     refreshUrls();
+  }
+
+  $(document).on('change', '#collection', function() {
+    setupOptions();
   });
 
   $(document).on('change', '#year', function() {
@@ -49,7 +54,7 @@
   });
 
   $(function() {
-    $('#collection').trigger('change');
+    setupOptions();
     refreshUrls();
   });
 </script>

--- a/app/views/pages/database/mapbiomas_collection.pt-BR.html.erb
+++ b/app/views/pages/database/mapbiomas_collection.pt-BR.html.erb
@@ -22,26 +22,31 @@
     });
   }
 
-  $(document).on('change', '#collection', function() {
-    if($(this).val() == '1') {
+  function setupOptions() {
+    var value = $('#collection').val();
+
+    if(value == '1') {
       $('#year').find('option').prop('disabled', false);
       $('#year').find('option[value="2016"]', 'option').prop('disabled', true);
       $('#year').find('option[value="all_years"]', 'option').prop('disabled', true);
       $('#year').find('option:first-child').prop('selected', true)
-    } else if($(this).val() == '2') {
+    } else if(value == '2') {
       $('#year').find('option').prop('disabled', false);
       $('#year').find('option[value="2016"]').prop('disabled', false);
       $('#year').find('option[value="all_years"]', 'option').prop('disabled', true);
       $('#year').find('option:first-child').prop('selected', true)
     } else {
-      $('#year').find('option').prop('disabled', true);
-      $('#year').find('option[value="all_years"]').prop('disabled', false);
+      $('#year').find('option[value!="all_years"]').prop('disabled', true);
       $('#year').find('option[value="all_years"]').prop('selected', true);
     }
 
     $('#year').trigger('change');
     
     refreshUrls();
+  }
+
+  $(document).on('change', '#collection', function() {
+    setupOptions();
   });
 
   $(document).on('change', '#year', function() {
@@ -49,7 +54,7 @@
   });
 
   $(function() {
-    $('#collection').trigger('change');
+    setupOptions();
     refreshUrls();
   });
 </script>


### PR DESCRIPTION
The `.tif` files provided for each of the biomes in collection 2.3 already includes all the year range (2000-2016), so there's no need to add those years as separated options; a `All years` option is enough.

|Before|After|
|---|---|
|![captura de tela de 2018-04-23 09-44-42](https://user-images.githubusercontent.com/4391802/39127429-65217750-46db-11e8-992b-7190999cf125.png)|![captura de tela de 2018-04-23 09-42-37](https://user-images.githubusercontent.com/4391802/39127436-69e92e18-46db-11e8-92a2-fc2e6b75dd21.png)|